### PR TITLE
Fixing ConfigManager - Type.parseLine()

### DIFF
--- a/lib/configManager/parsers/Type.js
+++ b/lib/configManager/parsers/Type.js
@@ -11,7 +11,7 @@ const { isTypeValid } = require('../Utils');
 const parseLine = (line) => {
   // Splits the line in <firstPart>=<value>
   const index = line.trim().indexOf('=');
-  const [firstPart, value] = [x.slice(0, index), x.slice(index+1)];
+  const [firstPart, value] = [x.slice(0, index), x.slice(index + 1)];
   // Checks if there is a type in the string
   if (firstPart.match(/:/g)) {
     // Separate the firstPart in <parameter>:<type>

--- a/lib/configManager/parsers/Type.js
+++ b/lib/configManager/parsers/Type.js
@@ -10,8 +10,9 @@ const { isTypeValid } = require('../Utils');
  */
 const parseLine = (line) => {
   // Splits the line in <firstPart>=<value>
-  const index = line.trim().indexOf('=');
-  const [firstPart, value] = [line.slice(0, index), line.slice(index + 1)];
+  const trimmedLine = line.trim();
+  const index = trimmedLine.indexOf('=');
+  const [firstPart, value] = [trimmedLine.slice(0, index), trimmedLine.slice(index + 1)];
   // Checks if there is a type in the string
   if (firstPart.match(/:/g)) {
     // Separate the firstPart in <parameter>:<type>

--- a/lib/configManager/parsers/Type.js
+++ b/lib/configManager/parsers/Type.js
@@ -11,7 +11,7 @@ const { isTypeValid } = require('../Utils');
 const parseLine = (line) => {
   // Splits the line in <firstPart>=<value>
   const index = line.trim().indexOf('=');
-  const [firstPart, value] = [x.slice(0, index), x.slice(index + 1)];
+  const [firstPart, value] = [line.slice(0, index), line.slice(index + 1)];
   // Checks if there is a type in the string
   if (firstPart.match(/:/g)) {
     // Separate the firstPart in <parameter>:<type>

--- a/lib/configManager/parsers/Type.js
+++ b/lib/configManager/parsers/Type.js
@@ -10,7 +10,8 @@ const { isTypeValid } = require('../Utils');
  */
 const parseLine = (line) => {
   // Splits the line in <firstPart>=<value>
-  const [firstPart, value] = line.trim().split('=');
+  const index = line.trim().indexOf('=');
+  const [firstPart, value] = [x.slice(0, index), x.slice(index+1)];
   // Checks if there is a type in the string
   if (firstPart.match(/:/g)) {
     // Separate the firstPart in <parameter>:<type>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If a configuration value has the character `'='` in its composition, the treatment does not act as expected, throwing everything away after the `'='`.

* **What is the new behavior (if this is a feature change)?**

The new behavior splits the line at the correct point.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

no

* **Other information**:

no