### PR TITLE
[config-manager] Fix comma parsing in string[]

### DIFF
--- a/lib/configManager/README.md
+++ b/lib/configManager/README.md
@@ -101,7 +101,7 @@ way of handling them. Examples of variables and types:
 scope1.param.boolean.key:boolean=true
 scope1.param.float.key:float=3.1415
 scope1.param.integer.key:integer=10
-scope1.param.string.array.key:string[]=["stringA", 'stringB']
+scope1.param.string.array.key:string[]=["stringA", "stringB"]
 scope2.param.explicit.string.key:string=this is explicitly typed as string
 scope2.param.implicit.string.key=this has the string type
 scope2.param.string.quotation.mark="strings are not delimited, these quotation marks will be in the string"
@@ -111,7 +111,7 @@ The accepted types are:
 - boolean: true or false, case insensitive.
 - float: any value with or without decimal places.
 - integer: any value without decimal places.
-- string[]: a list of strings, must be delimited by [ ] and each string must be delimited by ' or ".
+- string[]: a list of strings, must be delimited by `[ ]` and each string must be delimited by `"`.
 - string: if no type is passed, this is the default. There is no delimitation character.
 
 __NOTE THAT__ only the default configuration file can be typed. The user file and environment

--- a/lib/configManager/parsers/TypeConverter.js
+++ b/lib/configManager/parsers/TypeConverter.js
@@ -1,5 +1,3 @@
-const { result } = require("lodash");
-
 /**
  * Converts to boolean.
  *

--- a/lib/configManager/parsers/TypeConverter.js
+++ b/lib/configManager/parsers/TypeConverter.js
@@ -1,3 +1,5 @@
+const { result } = require("lodash");
+
 /**
  * Converts to boolean.
  *
@@ -47,15 +49,13 @@ const toStringArray = (value) => {
   if (!valueToString.match(/^\[.+\]$/)) {
     throw new Error('invalid array of strings');
   }
-  // Removing [ from the beginning and ] from the end
-  const stringArray = valueToString.slice(1, -1).split(',');
+  const resultingArray = JSON.parse(valueToString);
 
-  // Verifying whether all strings are correctly delimited by ' or "
-  if (!stringArray.every((str) => str.toString().trim().match(/^['"].+['"]$/))) {
-    throw new Error('found an invalid value in the passed array of strings');
+  const hasOnlyStrings = resultingArray.every((element) => typeof element === 'string');
+
+  if (!hasOnlyStrings) {
+    throw new Error('invalid value passed to a string[]');
   }
-  // Removing " from the beginning and the end
-  const resultingArray = stringArray.map((str) => str.trim().slice(1, -1));
 
   return resultingArray;
 };

--- a/test/unit/configManager/parsers/TypeConverter.test.js
+++ b/test/unit/configManager/parsers/TypeConverter.test.js
@@ -61,7 +61,7 @@ describe('string[]', () => {
   it('should convert', () => {
     expect(TypeConverter['string[]']('["1", "2", "3"]')).toEqual(['1', '2', '3']);
     expect(TypeConverter['string[]']('["1", "true", "3"]')).toEqual(['1', 'true', '3']);
-    expect(TypeConverter['string[]']('["1", "myString", "3"]')).toEqual(['1', 'myString', '3']);
+    expect(TypeConverter['string[]']('["1", "myString,a,b", "3"]')).toEqual(['1', 'myString,a,b', '3']);
   });
 
   it('should not convert - invalid delimiters', () => {

--- a/test/unit/configManager/parsers/TypeConverter.test.js
+++ b/test/unit/configManager/parsers/TypeConverter.test.js
@@ -59,11 +59,19 @@ describe('string', () => {
 
 describe('string[]', () => {
   it('should convert', () => {
-    expect(TypeConverter['string[]']('["1", "2", \'3\']')).toEqual(['1', '2', '3']);
+    expect(TypeConverter['string[]']('["1", "2", "3"]')).toEqual(['1', '2', '3']);
+    expect(TypeConverter['string[]']('["1", "true", "3"]')).toEqual(['1', 'true', '3']);
+    expect(TypeConverter['string[]']('["1", "myString", "3"]')).toEqual(['1', 'myString', '3']);
   });
 
   it('should not convert - invalid delimiters', () => {
     expect(() => TypeConverter['string[]']('("1", "2", "3")')).toThrow();
     expect(() => TypeConverter['string[]']('["1", [2], "3"]')).toThrow();
+    expect(() => TypeConverter['string[]']('["1", {2}, "3"]')).toThrow();
+    expect(() => TypeConverter['string[]']('[\'1\', \'2\', \'3\']')).toThrow();
+    expect(() => TypeConverter['string[]']('["1", \'2\', "3"]')).toThrow();
+    expect(() => TypeConverter['string[]']('["1", 2, "3"]')).toThrow();
+    expect(() => TypeConverter['string[]']('["1", true, "3"]')).toThrow();
+    expect(() => TypeConverter['string[]']('["1", myString, "3"]')).toThrow();
   });
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Check the linked issue.


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
**Yes**. Since the parsing is now made via `JSON.parse`, the parameters with `string[]` should not use single quotes for its values, only double quotes.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
https://github.com/dojot/dojot/issues/1764

* **Other information**: