### PR TITLE
[Fix - SonarQube] Missing document start "---"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 coverage:
   status:
     project:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Sonar Qube - code smell

* **What is the current behavior?** (You can also link to an open issue here)

The document did not start with "---"

* **What is the new behavior (if this is a feature change)?**

For correct parsing especially in the case of multiple or embedded documents, documents should start with a document start marker

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

Internal SonarQube

* **Other information**: