### PR TITLE
Fix with warn message when graceful shutdown is not the last instruction in the event loop

### DIFF
--- a/lib/serviceStateManager/ServiceStateManager.js
+++ b/lib/serviceStateManager/ServiceStateManager.js
@@ -27,7 +27,10 @@ class ServiceStateManager {
     // Applying the configurations
     const defaultLightshipConfig = {
       detectKubernetes: false,
-      terminate: () => { process.exit(0); },
+      terminate: () => {
+        this.logger.warn('process did not exit on its own; investigate what is keeping the event loop active');
+        process.exit(1);
+      },
     };
 
     /**


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

ServiceStateManager was ending the process with status 0, but it should end with status 1 to signal that there was still something to be done in the node.js event loop.

* **What is the new behavior (if this is a feature change)?**

In addition to ending the process with an error status, a warning message is also logged to know that something unexpected was scheduled to be executed in the Node event loop. In such cases it is necessary to investigate what is getting rubbish in the event loop that was not finished by the shutdown handlers.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no 

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

no

* **Other information**: