### PR TITLE
Interceptor to stop requests when the application is not ready

### DIFF
--- a/lib/serviceStateManager/ServiceStateManager.js
+++ b/lib/serviceStateManager/ServiceStateManager.js
@@ -65,6 +65,8 @@ class ServiceStateManager {
     this.shutdown = this.lightship.shutdown.bind(this.lightship);
     this.registerShutdownHandler(this.removeAllServices.bind(this));
 
+    this.readyState = false;
+
     this.logger.info('... ServiceStateManager initialized.');
   }
 
@@ -85,6 +87,7 @@ class ServiceStateManager {
     } else {
       this.lightship.signalNotReady();
     }
+    this.readyState = isReady;
   }
 
   /**
@@ -137,6 +140,17 @@ class ServiceStateManager {
     // We need to call the code inside an immediate because the states of other services were being
     // overwritten
     setImmediate(this.updateState.bind(this, service, false));
+  }
+
+  /**
+   * Indicates whether all services are ready or not
+   *
+   * @returns true if all services are ready (according to the last check), otherwise, false.
+   *
+   * @public
+   */
+  isReady() {
+    return (this.readyState);
   }
 
   /**

--- a/lib/webUtils/createTokenGen.js
+++ b/lib/webUtils/createTokenGen.js
@@ -1,0 +1,32 @@
+const jwt = require('jsonwebtoken');
+const { promisify } = require('util');
+
+const jwtSignAsync = promisify(jwt.sign).bind(jwt);
+
+function createTokenGen() {
+  /**
+   * Sign the given payload into a JSON Web Token string
+   *
+   * @param {object} data - data for JWT generation
+   */
+  const generate = async ({
+    payload = {},
+    tenant = '',
+    expirationSec = 60,
+    secret = 'secret',
+  }) => {
+    const innerPayload = { ...payload };
+    if (typeof innerPayload.service !== 'string') {
+      innerPayload.service = tenant;
+    }
+    const token = await jwtSignAsync(innerPayload, secret, { expiresIn: expirationSec });
+    return token;
+  };
+
+  // returns an object of type "TokenGen"
+  return Reflect.construct(function TokenGen() {
+    this.generate = generate;
+  }, []);
+}
+
+module.exports = () => createTokenGen();

--- a/lib/webUtils/framework/interceptors/readinessInterceptor.js
+++ b/lib/webUtils/framework/interceptors/readinessInterceptor.js
@@ -1,0 +1,26 @@
+const createError = require('http-errors');
+
+/**
+ * Interceptor to allow requests only when the application is ready
+ */
+function createInterceptor(stateManager, logger, path = '/', environment = process.env.NODE_ENV) {
+  return {
+    path,
+    name: 'readiness-interceptor',
+    middleware: (req, res, next) => {
+      if (environment === 'development') {
+        logger.debug('The application is not ready, but the request will be handled in a development environment');
+        next();
+      } else if (stateManager.isReady()) {
+        next();
+      } else {
+        logger.error('The application is not in a ready state, the request cannot be handled');
+        next(new createError.ServiceUnavailable());
+      }
+    },
+  };
+}
+
+module.exports = ({
+  stateManager, logger, path, environment,
+} = {}) => createInterceptor(stateManager, logger, path, environment);

--- a/lib/webUtils/framework/interceptors/tokenParsingInterceptor.js
+++ b/lib/webUtils/framework/interceptors/tokenParsingInterceptor.js
@@ -1,0 +1,46 @@
+const createError = require('http-errors');
+const jwtDecode = require('jwt-decode');
+
+/**
+ * Decodes the JWT token that must be sent with the request.
+ * The token validation is not performed, as it is expected
+ * to be validated by the API Gateway.
+ *
+ * @param {Array}  ignoredPaths List of paths ignored by JWT verification
+ * @param {string} path URL where the interceptor will be fired
+ */
+function createInterceptor(ignoredPaths = [], path = '/') {
+  return {
+    path,
+    name: 'token-parsing-interceptor',
+    middleware: (req, res, next) => {
+      const err = new createError.Unauthorized();
+
+      if (ignoredPaths.some((ignore) => req.path.includes(ignore))) {
+        return next();
+      }
+
+      if (req.headers.authorization) {
+        const authHeader = req.headers.authorization.split(' ');
+
+        if (authHeader.length === 2 && authHeader[0] === 'Bearer') {
+          const token = authHeader[1];
+          const payload = jwtDecode(token);
+
+          if (payload.service) {
+            req.tenant = payload.service;
+            return next();
+          }
+        }
+
+        err.message = 'Invalid JWT token';
+        return next(err);
+      }
+
+      err.message = 'Missing JWT token';
+      return next(err);
+    },
+  };
+}
+
+module.exports = ({ ignoredPaths, path } = {}) => createInterceptor(ignoredPaths, path);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/microservice-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1703,6 +1703,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2285,6 +2290,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -5381,6 +5394,35 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5391,6 +5433,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -5553,10 +5614,45 @@
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
     "lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5454,6 +5454,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "jsonwebtoken": "^8.5.1",
+    "jwt-decode": "^3.1.2",
     "lightship": "^6.2.1",
     "lodash": "^4.17.19",
     "morgan": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "fast-safe-stringify": "^2.0.7",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
+    "jsonwebtoken": "^8.5.1",
     "lightship": "^6.2.1",
     "lodash": "^4.17.19",
     "morgan": "^1.10.0",

--- a/test/unit/webUtils/framework/createTokenGen.test.js
+++ b/test/unit/webUtils/framework/createTokenGen.test.js
@@ -1,0 +1,13 @@
+const createTokenGen = require('../../../../lib/webUtils/createTokenGen');
+
+describe("Unit tests of script 'tokenGen.js'", () => {
+  let tokenGen = null;
+
+  beforeAll(() => {
+    tokenGen = createTokenGen();
+  });
+
+  it("should generate a dummy token with tenant equal 'admin'", () => expect(tokenGen.generate({ tenant: 'admin' })).resolves.toBeDefined());
+
+  it('should generate a dummy token with a custom payload', () => expect(tokenGen.generate({ payload: { service: 'admin' } })).resolves.toBeDefined());
+});

--- a/test/unit/webUtils/framework/interceptors/beaconInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/beaconInterceptor.test.js
@@ -1,0 +1,91 @@
+jest.mock('on-finished');
+
+const onFinished = require('on-finished');
+const { Logger } = require('../../../../../lib/logging/Logger');
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/beaconInterceptor');
+
+function stateManagerMock() {
+  const beacon = {
+    die: jest.fn(),
+  };
+  const stateManager = {
+    createBeacon: jest.fn(() => beacon),
+    beacon,
+    isServerShuttingDown: jest.fn(() => false),
+  };
+  return stateManager;
+}
+
+describe("Unit tests of script 'beaconInterceptor.js'", () => {
+  let beaconInterceptor = null;
+  let stateManager = null;
+  let logger = null;
+
+  beforeAll(() => {
+    logger = new Logger('beaconInterceptor.test.js');
+    logger.debug = jest.fn();
+    logger.error = jest.fn();
+  });
+
+  beforeEach(() => {
+    stateManager = stateManagerMock();
+    beaconInterceptor = createInterceptor({
+      stateManager,
+      logger,
+    });
+    onFinished.mockImplementation((res, callback) => callback());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create an interceptor without parameters', () => {
+    expect(createInterceptor()).toBeDefined();
+  });
+
+  it('should successfully run the interceptor middleware', () => {
+    const req = { id: '123456' };
+    const res = {};
+    const next = jest.fn();
+
+    expect(beaconInterceptor.middleware(req, res, next)).toBeUndefined();
+
+    expect(onFinished).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+
+    expect(logger.error).toHaveBeenCalledTimes(0);
+    expect(logger.debug).toHaveBeenCalledTimes(2);
+    expect(stateManager.beacon.die).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw an exception because the 'server' is shutting down", () => {
+    // simulates a condition in which the server is being shut down
+    stateManager.isServerShuttingDown = jest.fn(() => true);
+
+    const req = { id: '123456' };
+    const res = {};
+    const next = jest.fn();
+
+    expect(() => {
+      beaconInterceptor.middleware(req, res, next);
+    }).toThrow();
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('should simulate an error request', () => {
+    onFinished.mockImplementation((res, callback) => callback(new Error('Async error')));
+
+    const req = { id: '123456' };
+    const next = jest.fn();
+
+    expect(beaconInterceptor.middleware(req, {}, next)).toBeUndefined();
+    expect(onFinished).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledTimes(2);
+    expect(stateManager.beacon.die).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/jsonBodyParsingInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/jsonBodyParsingInterceptor.test.js
@@ -1,0 +1,13 @@
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/jsonBodyParsingInterceptor');
+
+describe("Unit tests of script 'jsonBodyParsingInterceptor.js'", () => {
+  it('should create an interceptor with parameters', () => {
+    expect(createInterceptor({ config: { limit: '100kb' } })).toBeDefined();
+  });
+
+  it('should not create an interceptor without parameters', () => {
+    expect(() => {
+      createInterceptor();
+    }).toThrow();
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/paginateInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/paginateInterceptor.test.js
@@ -1,0 +1,11 @@
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/paginateInterceptor');
+
+describe("Unit tests of script 'paginateInterceptor.js'", () => {
+  it('should create an interceptor with parameters', () => {
+    expect(createInterceptor({ limit: 25, maxLimit: 250 })).toBeDefined();
+  });
+
+  it('should create an interceptor without parameters', () => {
+    expect(createInterceptor()).toBeDefined();
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/readinessInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/readinessInterceptor.test.js
@@ -1,0 +1,85 @@
+const { Logger } = require('../../../../../lib/logging/Logger');
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/readinessInterceptor');
+
+function stateManagerMock() {
+  const stateManager = {
+    isReady: jest.fn(() => true),
+  };
+  return stateManager;
+}
+
+describe("Unit tests of script 'readinessInterceptor.js'", () => {
+  let readinessInterceptor = null;
+  let stateManager = null;
+  let logger = null;
+
+  beforeAll(() => {
+    logger = new Logger('readinessInterceptor.test.js');
+    logger.debug = jest.fn();
+    logger.error = jest.fn();
+  });
+
+  beforeEach(() => {
+    stateManager = stateManagerMock();
+    readinessInterceptor = createInterceptor({
+      stateManager,
+      logger,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create an interceptor without parameters', () => {
+    expect(createInterceptor()).toBeDefined();
+  });
+
+  it('should successfully run the interceptor middleware', () => {
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    expect(readinessInterceptor.middleware(req, res, next)).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+    expect(logger.debug).toHaveBeenCalledTimes(0);
+    expect(stateManager.isReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw an exception because the application is not ready', () => {
+    // simulates a condition in which the application is not ready
+    stateManager.isReady = jest.fn(() => false);
+
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    expect(readinessInterceptor.middleware(req, res, next)).toBeUndefined();
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledTimes(0);
+    expect(stateManager.isReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('should simulate an development environment', () => {
+    readinessInterceptor = createInterceptor({
+      stateManager,
+      logger,
+      environment: 'development',
+    });
+
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    expect(readinessInterceptor.middleware(req, res, next)).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(stateManager.isReady).toHaveBeenCalledTimes(0);
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/requestIdInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/requestIdInterceptor.test.js
@@ -1,0 +1,11 @@
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/requestIdInterceptor');
+
+describe("Unit tests of script 'requestIdInterceptor.js'", () => {
+  it('should create an interceptor with parameters', () => {
+    expect(createInterceptor({ path: '/api/v1' })).toBeDefined();
+  });
+
+  it('should create an interceptor without parameters', () => {
+    expect(createInterceptor()).toBeDefined();
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/requestLogInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/requestLogInterceptor.test.js
@@ -1,0 +1,32 @@
+jest.mock('morgan');
+
+const morgan = require('morgan');
+
+morgan.mockImplementation((logFormat, config) => {
+  config.stream.write('test some log message');
+});
+
+morgan.token = jest.fn((key, callback) => callback({ id: '123456' }));
+
+
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/requestLogInterceptor');
+const { Logger } = require('../../../../../lib/logging/Logger');
+
+const logger = new Logger('beaconInterceptor.test.js');
+logger.info = jest.fn();
+
+describe("Unit tests of script 'requestLogInterceptor.js'", () => {
+  it('should create an interceptor with parameters', () => {
+    expect(createInterceptor({
+      path: '/api/v1',
+      logger,
+      logFormat: ':id',
+    })).toBeDefined();
+  });
+
+  it('should not create an interceptor without parameters', () => {
+    expect(() => {
+      createInterceptor();
+    }).toThrow();
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/responseCompressInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/responseCompressInterceptor.test.js
@@ -1,0 +1,11 @@
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/responseCompressInterceptor');
+
+describe("Unit tests of script 'responseCompressInterceptor.js'", () => {
+  it('should create an interceptor with parameters', () => {
+    expect(createInterceptor({ path: '/api/v1' })).toBeDefined();
+  });
+
+  it('should create an interceptor without parameters', () => {
+    expect(createInterceptor()).toBeDefined();
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/staticFileInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/staticFileInterceptor.test.js
@@ -1,0 +1,33 @@
+jest.mock('path');
+jest.mock('express');
+jest.mock('serve-index');
+
+const pathModule = require('path');
+const express = require('express');
+
+pathModule.dirname = jest.fn((path) => {
+  if (!path) {
+    throw new Error('The "path" argument must be of type string. Received undefined');
+  }
+});
+
+express.static = jest.fn();
+
+
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/staticFileInterceptor');
+
+describe("Unit tests of script 'staticFileInterceptor.js'", () => {
+  it('should create an interceptor with parameters', () => {
+    expect(createInterceptor({
+      path: '/api/v1',
+      baseDirectory: '/etc/test',
+      staticFilePath: '/relative/path/to/static/files',
+    })).toBeDefined();
+  });
+
+  it('should not create an interceptor without parameters', () => {
+    expect(() => {
+      createInterceptor();
+    }).toThrow();
+  });
+});

--- a/test/unit/webUtils/framework/interceptors/tokenParsingInterceptor.test.js
+++ b/test/unit/webUtils/framework/interceptors/tokenParsingInterceptor.test.js
@@ -1,0 +1,113 @@
+const createInterceptor = require('../../../../../lib/webUtils/framework/interceptors/tokenParsingInterceptor');
+const createTokenGen = require('../../../../../lib/webUtils/createTokenGen');
+
+describe("Unit tests of script 'tokenParsingInterceptor.js'", () => {
+  let tokenGen = null;
+
+  beforeAll(() => {
+    tokenGen = createTokenGen();
+  });
+
+  it('should create an interceptor with parameters', () => {
+    expect(createInterceptor({
+      path: '/internal',
+      ignoredPaths: ['internal/api/v1', 'internal/api/v2'],
+    })).toBeDefined();
+  });
+
+  it('should create an interceptor without parameters', () => {
+    expect(createInterceptor()).toBeDefined();
+  });
+
+  it('should successfully run the interceptor middleware', async () => {
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    const tokenParsingInterceptor = createInterceptor();
+
+    const jwt = await tokenGen.generate({ tenant: 'admin' });
+
+    req.path = '/';
+    req.headers = {};
+    req.headers.authorization = `Bearer ${jwt}`;
+
+    expect(tokenParsingInterceptor.middleware(req, res, next)).toBeUndefined();
+    expect(req.tenant).toBe('admin');
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeUndefined();
+  });
+
+  it('should generate an error because of a invalid JWT token', async () => {
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    const tokenParsingInterceptor = createInterceptor();
+
+    const jwt = await tokenGen.generate({ tenant: 'admin' });
+
+    req.path = '/';
+    req.headers = {};
+    req.headers.authorization = `${jwt}`; // missing: "Bearer"
+
+    expect(tokenParsingInterceptor.middleware(req, res, next)).toBeUndefined();
+    expect(req.tenant).toBe(undefined);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('should generate an error because of a missing JWT token', () => {
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    const tokenParsingInterceptor = createInterceptor();
+
+    req.path = '/';
+    req.headers = {};
+
+    expect(tokenParsingInterceptor.middleware(req, res, next)).toBeUndefined();
+    expect(req.tenant).toBe(undefined);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('should generate an error because the JWT token does not contain a tenant', () => {
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    const tokenParsingInterceptor = createInterceptor();
+
+    // A JWT token without the "service" attribute (tenant)
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTM2Nzg0OTMsImV4cCI6MTYxMzY3ODU1M30.c5oCtfRdiqt8jeBAnLqeuGQiAd4D6ELf7dOxSZWs478';
+
+    req.path = '/';
+    req.headers = {};
+    req.headers.authorization = `Bearer ${jwt}`;
+
+    expect(tokenParsingInterceptor.middleware(req, res, next)).toBeUndefined();
+    expect(req.tenant).toBe(undefined);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('should simulate an ignored path', () => {
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    const tokenParsingInterceptor = createInterceptor({
+      ignoredPaths: ['throw-away'],
+    });
+
+    req.path = '/internal/api/v1/throw-away';
+    req.headers = {};
+
+    expect(tokenParsingInterceptor.middleware(req, res, next)).toBeUndefined();
+    expect(req.tenant).toBe(undefined);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

The application, even if not ready, accepts requests. This behavior can put the application in an undetermined state.

* **What is the new behavior (if this is a feature change)?**

The application starts accepting requests only when _ServiceStateManager_ finds that all the exceptional services that the application uses are in readiness.

There is a bypass when the `NODE_ENV` environment variable is set to `development`, in this case, the interceptor stops working.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

no

* **Other information**: