### PR TITLE
Modified the consumer to support an asynchronous commit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ attend the dojot microservices necessities.
   - [Backend Web Utils](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/lib/webUtils/README.md)
 - Examples
   - [Configuration Manager](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/examples/configManager/README.md)
-  - [Kafka's Consumer](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/examples/consumer/README.md)
+  - [Kafka's Consumer (Sync Commit)](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/examples/consumer/README.md)
+  - [Kafka's Consumer (Async Commit)](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/examples/asyncConsumer/README.md)
   - [Kafka's Producer](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/examples/producer/README.md)
   - [Logger](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/examples/logging/README.md)
   - [Service State Manager](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/examples/serviceStateManager/README.md)

--- a/examples/asyncConsumer/Dockerfile
+++ b/examples/asyncConsumer/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:12.18.4-alpine AS base
+
+WORKDIR /opt/example
+
+RUN apk --no-cache add \
+    bash \
+    g++ \
+    ca-certificates \
+    lz4-dev \
+    musl-dev \
+    cyrus-sasl-dev \
+    openssl-dev \
+    make \
+    python
+
+RUN apk add --no-cache --virtual .build-deps gcc zlib-dev libc-dev bsd-compat-headers py-setuptools bash
+
+COPY package.json package.json
+COPY npm-shrinkwrap.json npm-shrinkwrap.json
+
+RUN npm install
+
+COPY lib ./lib
+COPY index.js index.js
+COPY examples/asyncConsumer/sample.js ./app/sample.js
+
+FROM node:12.18.4-alpine
+
+WORKDIR /opt/example
+
+RUN apk --no-cache add \
+    libsasl \
+    lz4-libs
+
+COPY --from=base /opt/example /opt/example
+CMD ["node", "app/sample.js"]

--- a/examples/asyncConsumer/README.md
+++ b/examples/asyncConsumer/README.md
@@ -1,6 +1,6 @@
-# Basic Consumer (Sync Commit)
+# Basic Consumer (Async Commit)
 
-This example implements a [basic consumer](sample.js) which registers a single callback to log messages published to a specific topic. The consumer uses the synchronous commit mechanism.
+This example implements a [basic consumer](sample.js) which registers a single callback to log messages published to a specific topic in an asynchronous way. The consumer uses the asynchronous commit mechanism.
 
 It is also provided a [Docker Compose file](docker-compose.yml) with the whole environment to see the consumer in action, including a service that publishes messages to kafka every 5 seconds.
 

--- a/examples/asyncConsumer/docker-compose.yml
+++ b/examples/asyncConsumer/docker-compose.yml
@@ -1,0 +1,59 @@
+version: '3.7'
+services:
+
+  zookeeper:
+    image: dojot/zookeeper:3.4
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  kafka:
+    image: dojot/wurstmeister-kafka:2.12-2.1.1
+    depends_on:
+      - zookeeper
+    restart: always
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_TOPICS: 'consumer.example.test'
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  kafkacat-producer:
+    image: confluentinc/cp-kafkacat:latest
+    depends_on:
+      - kafka
+    restart: always
+    command: >
+      bash -c "
+        for ((i=0; ; i++)) do
+          echo \"Test Message - $${i}\" |\
+          kafkacat -b kafka:9092 -P -t consumer.example.test
+          sleep 5
+        done
+      "
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  async-consumer:
+    build:
+      context: ./../../
+      dockerfile: ./examples/asyncConsumer/Dockerfile
+    depends_on:
+      - kafka
+    environment:
+      KAFKA_HOSTS: kafka:9092
+      KAFKA_GROUP_ID: sdk-consumer-example
+      KAFKA_TOPIC: consumer.example.test
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m

--- a/examples/asyncConsumer/sample.js
+++ b/examples/asyncConsumer/sample.js
@@ -1,0 +1,71 @@
+const util = require('util');
+const { Logger, Kafka: { Consumer } } = require('../index.js');
+
+
+// Set the global logger properties
+// Console transport is set by default, but with info level
+Logger.setLevel('console', 'debug');
+
+// Enable verbose mode
+Logger.setVerbose(true);
+
+// instantiate a logger wrapper for the application
+const logger = new Logger('sample-consumer');
+
+const consumer = new Consumer({
+  'enable.async.commit': true,
+  'commit.on.failure': false,
+  'kafka.consumer': {
+    'group.id': process.env.KAFKA_GROUP_ID || 'sdk-consumer-example',
+    'metadata.broker.list': process.env.KAFKA_HOSTS || 'localhost:9092',
+  },
+  'kafka.topic': {
+    'auto.offset.reset': 'earliest',
+  },
+});
+
+consumer.on('ready',
+  () => logger.info('Received ready event'));
+consumer.on('disconnected',
+  () => logger.info('Received disconnected event'));
+consumer.on('paused',
+  () => logger.info('Received paused event'));
+consumer.on('resumed',
+  () => logger.info('Received resumed event'));
+consumer.on('error.connecting',
+  () => logger.info('Received error.connecting event'));
+consumer.on('error.processing',
+  (cbId, data) => logger.info(
+    `Received error.processing event (cbId: ${cbId}: data: ${util.inspect(data)})`,
+  ));
+
+const getStatusFunc = () => {
+  consumer.getStatus().then((value) => {
+    logger.info(`Status: ${util.inspect(value)}`);
+  }).catch((err) => {
+    logger.error(`${err}`);
+  });
+};
+
+consumer.init().then(() => {
+  logger.info('Application is ready to receive messages from kafka!');
+  // the target kafka topic, it could be a String or a RegExp
+  const targetTopic = process.env.KAFKA_TOPIC || 'consumer.testing';
+
+  /**
+   * retrieve the status
+   */
+  setInterval(getStatusFunc, 5000);
+
+  // Register callback to process incoming device data
+  /* const idCallback = */ consumer.registerCallback(targetTopic, (data, ack) => {
+    const { value: payload } = data;
+    logger.debug(`Start processing: ${payload.toString()}`);
+    setTimeout(async () => {
+      logger.debug(`Finished processing: ${payload.toString()}`);
+      ack();
+    }, 60000 * Math.random());
+  });
+}).catch((error) => {
+  logger.error(`Caught an error: ${error.stack || error}`);
+});

--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -93,7 +93,7 @@ const EVENTS = [
   'disconnected',
   // emitted when the consumer stops consuming from Kafka (backpressure)
   'paused',
-  // emitted when the consunmer starts consuming from Kafka again (backpressure)
+  // emitted when the consumer starts consuming from Kafka again (backpressure)
   'resumed',
   // emitted when the connection with Kafka failed
   'error.connecting',
@@ -108,7 +108,7 @@ const EVENTS = [
  * for processing the same message.
  * - a backpressure mechanism to control the consumption of messages from kafka
  * according to the processing ratio.
- * - a commit management that ensures that all messages will be procecessed at
+ * - a commit management that ensures that all messages will be processed at
  * least once.
  */
 module.exports = class Consumer {
@@ -119,26 +119,26 @@ module.exports = class Consumer {
    * - "in.processing.max.messages": the maximum number of messages being
    * processed simultaneously. The processing callbacks are called in order but
    * there is no guarantee regarding to the order of completion
-   * - "enable.async.commit": true if the asyncronous mode is enabled; otherwise, false.
+   * - "enable.async.commit": true if the asynchronous mode is enabled; otherwise, false.
    *  In the synchronous mode, a message is marked to be committed immediately after
    * its processing callbacks have finished
    * In the asynchronous mode, a message is committed immediately after its
-   * acknoledgements have been received.
+   * acknowledgements have been received.
    * - "max.retries.processing.callbacks": the maximum number of times a processing
    * callback will be called if it fails.
-   * - "commit.on.failure": true if a message should be commited even if its
+   * - "commit.on.failure": true if a message should be committed even if its
    * processing has failed; false, otherwise. This property applies only to synchronous mode.
    * - "queued.max.messages.bytes": the maximum amount (in bytes) of queued
    * messages waiting for being processed. The same queue is shared by all callbacks.
-   * - "subscription.backoff.min.ms": the initial backoff time (in miliseconds) for
+   * - "subscription.backoff.min.ms": the initial backoff time (in milliseconds) for
    * subscribing to topics in Kafka. Every time a callback is registered for a new topic,
    * the subscriptions are updated to include this new one.
-   * - "subscription.backoff.max.ms": the maximum value for the backoff time (in miliseconds).
+   * - "subscription.backoff.max.ms": the maximum value for the backoff time (in milliseconds).
    * The backoff time is incremented while it is above this value.
    * - "subscription.backoff.delta.ms": the value that will be used for calculating a random
-   * delta time (in miliseconds) in the exponential delay between retries.
-   * - "commit.interval.ms": time interval (in miliseconds) for commiting the processed messages
-   * into kafka. A message is commited if and only if all previous messages has been processed.
+   * delta time (in milliseconds) in the exponential delay between retries.
+   * - "commit.interval.ms": time interval (in milliseconds) for committing the processed messages
+   * into kafka. A message is committed if and only if all previous messages has been processed.
    * - kafka.consumer: an object with global properties for the node-rdkafka consumer. For a full
    * list of the properties, see:
    * https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#global-configuration-properties.
@@ -231,7 +231,9 @@ module.exports = class Consumer {
 
     // async commit mode
     this.unackMsgBytes = 0;
-    this.unackMsgs = {};
+    // the epoch changes when a rebalance happens,
+    // and uncommitted messages will be handled again
+    // by this instance or another one
     this.epoch = 0;
 
     // event emitter
@@ -279,7 +281,6 @@ module.exports = class Consumer {
         this.currQueueBytes = 0;
         this.isPaused = false;
         this.msgQueue = null;
-        this.unackMsgs = {};
         this.unackMsgBytes = 0;
         this.epoch = 0;
         this.eventEmitter.emit('disconnected');
@@ -307,7 +308,7 @@ module.exports = class Consumer {
    *  ready emitted when the consumer is ready
    *  disconnected emitted when the consumer is disconnected from Kafka by the client
    *  paused emitted when the consumer is paused (backpressure)
-   *  resumed emitted when the consunmer is resumed
+   *  resumed emitted when the consumer is resumed
    *  error.connecting emitted when the connection with Kafka failed
    *  error.processing emitted when a message couldn't be processed
    * @param {*} callback
@@ -478,7 +479,7 @@ module.exports = class Consumer {
    *
    * @access private
    * @param {*} retries the number of retries.
-   * @return the waiting time for the next attempt in miliseconds.
+   * @return the waiting time for the next attempt in milliseconds.
    */
   backoffWithRandomDelta(retries) {
     const waitingTime = (
@@ -542,12 +543,12 @@ module.exports = class Consumer {
    * Handles the kafka's rebalance event.
    *
    * Once a rebalance occurs, it's no longer needed to handle the remaining queued
-   * messages, as all uncommited messages will be redelivered to the new assignee
+   * messages, as all uncommitted messages will be redelivered to the new assignee
    * that is part of the consumer group. Consequently, the processing queue is drained
    * and the uncommitted offsets are discarded.
    *
    * ATTENTION: A message might be processed more than once if a rebalance occurs
-   * and some processed messages has not be commited.
+   * and some processed messages has not be committed.
    * @access private
    * @param {*} error the error code
    * @param {*} assignments the assignments
@@ -558,9 +559,8 @@ module.exports = class Consumer {
     } else if (error.code === Kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
       this.resumeConsumer();
       // when partition are revoked we just abort queued tasks and do not
-      // commit any processed task that is waiting for be commited into Kafka.
+      // commit any processed task that is waiting for be committed into Kafka.
       this.msgQueue.remove(() => true);
-      this.unackMsgs = {};
       this.unackMsgBytes = 0;
       this.epoch = (this.epoch + 1) % Number.MAX_SAFE_INTEGER;
       this.consumer.unassign();
@@ -615,7 +615,7 @@ module.exports = class Consumer {
    * by n-times according its configuration. If the callback
    * has not succeeded after the n-retries, an 'error.processing' event is emitted.
    *
-   * Depending on the configuration, the message that coundn't be processed is
+   * Depending on the configuration, the message that couldn't be processed is
    * marked to be committed on Kafka, and the consumer continues working as nothing
    * has happened (message discarded). But, if the message can't be discarded, it
    * won't be marked to be committed on Kafka and  the consumer will be finished.
@@ -732,31 +732,38 @@ module.exports = class Consumer {
     // the current epoch
     const { epoch } = this;
 
-    // key of the kafka message
-    const key = JSON.stringify({
-      topic: data.topic,
-      partition: data.partition,
-      offset: data.offset,
-    });
+    // counter to the unacknowledged callbacks
+    //
+    // Notice that multiple callbacks might be
+    // called to the same message, and when the counter
+    // becomes 0 is safe to mark the message to
+    // be committed on Kafka (all acks have been
+    // received). Before calling the callbacks
+    // the counter is set to 1 and is incremented
+    // for each callback and decremented for each
+    // corresponding ack. It is also decremented after
+    // calling all callbacks.
+    // Incrementing before calling the callbacks and
+    // decrementing after calling all callbacks guarantees
+    // that the counter doesn't become 0 before all
+    // callbacks are called.
+    let unackCounter = 1;
 
     // acknowledge callback
     //
     // It is supposed that the ack will be called if
     // and only if its corresponding callback succeeded.
     const ack = () => {
-      if (epoch !== this.epoch
-        || !Object.prototype.hasOwnProperty.call(this.unackMsgs, key)) return;
-      this.unackMsgs[key] -= 1;
-      if (this.unackMsgs[key] === 0) {
+      if (epoch !== this.epoch) {
+          return false;
+      }
+      unackCounter -=1;
+      if (unackCounter === 0) {
         this.commitManager.notifyFinishedProcessing(data);
         this.unackMsgBytes -= data.size;
-        delete this.unackMsgs[key];
       }
+      return true;
     };
-
-    // sets here to guarantee that all callbacks are called
-    // before committing on Kafka.
-    this.unackMsgs[key] = 1;
 
     // set backpressure control
     this.unackMsgBytes += data.size;
@@ -770,7 +777,7 @@ module.exports = class Consumer {
         if (entry.regExp.test(data.topic)) {
           let retry = 0;
           let succeeded = false;
-          this.unackMsgs[key] += 1;
+          unackCounter += 1;
 
           // called is a guard to guarantee that ack
           // is called once by each callback
@@ -778,8 +785,9 @@ module.exports = class Consumer {
           const ackOnce = () => {
             if (!called) {
               called = true;
-              ack();
+              return ack();
             }
+            return false;
           };
 
           /* eslint-disable no-await-in-loop */
@@ -797,7 +805,7 @@ module.exports = class Consumer {
           } while ((!succeeded) && retry <= this.config['max.retries.processing.callbacks']);
           if (!succeeded) {
             logger.error(`Callback ${entry.id} failed in all attempts (${retry})`);
-            this.unackMsgs[key] -= 1;
+            unackCounter -= 1;
             anyProcessingFailure = true;
             this.eventEmitter.emit('error.processing', entry.id, data);
           }
@@ -812,7 +820,7 @@ module.exports = class Consumer {
       this.topicMap[data.topic].forEach(async (entry) => {
         let retry = 0;
         let succeeded = false;
-        this.unackMsgs[key] += 1;
+        unackCounter += 1;
 
         // called is guard to guarantee that ack
         // is called once by each callback
@@ -820,8 +828,9 @@ module.exports = class Consumer {
         const ackOnce = () => {
           if (!called) {
             called = true;
-            ack();
+            return ack();
           }
+          return false;
         };
 
         /* eslint-disable no-await-in-loop */
@@ -839,7 +848,7 @@ module.exports = class Consumer {
         } while ((!succeeded) && retry <= this.config['max.retries.processing.callbacks']);
         if (!succeeded) {
           logger.error(`Callback ${entry.id} failed in all attempts (${retry})`);
-          this.unackMsgs[key] -= 1;
+          unackCounter -= 1;
           anyProcessingFailure = true;
           this.eventEmitter.emit('error.processing', entry.id, data);
         }
@@ -848,15 +857,13 @@ module.exports = class Consumer {
       logger.warn(`Internal error during processing message: ${error}`);
       this.eventEmitter.emit('error.processing', null, data);
     } finally {
-      this.unackMsgs[key] -= 1;
+      unackCounter -= 1;
       if (anyProcessingFailure) {
         this.unackMsgBytes -= data.size;
-        delete this.unackMsgs[key];
         logger.error('Consumer cannot keep working properly. Finishing consumer.');
         this.finish();
-      } else if (this.unackMsgs[key] === 0) {
+      } else if (unackCounter === 0) {
         this.unackMsgBytes -= data.size;
-        delete this.unackMsgs[key];
         this.commitManager.notifyFinishedProcessing(data);
       }
     }

--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -21,6 +21,11 @@ const logger = new Logger('microservice-sdk:consumer');
 const DEFAULT_IN_PROCESSING_MAX_MESSAGES = 1;
 
 /**
+ * Default value for enabling asynchronous commit mode.
+ */
+const DEFAULT_ENABLE_ASYNC_COMMIT = false;
+
+/**
  * Default value for the maximum number of retries to call
  * a processing callback.
  */
@@ -113,11 +118,16 @@ module.exports = class Consumer {
    * It is an object with the following properties:
    * - "in.processing.max.messages": the maximum number of messages being
    * processed simultaneously. The processing callbacks are called in order but
-   * there is no guarantee regarding to the order of completion.
+   * there is no guarantee regarding to the order of completion
+   * - "enable.async.commit": true if the asyncronous mode is enabled; otherwise, false.
+   *  In the synchronous mode, a message is marked to be committed immediately after
+   * its processing callbacks have finished
+   * In the asynchronous mode, a message is committed immediately after its
+   * acknoledgements have been received.
    * - "max.retries.processing.callbacks": the maximum number of times a processing
    * callback will be called if it fails.
    * - "commit.on.failure": true if a message should be commited even if its
-   * processing has failed; false, otherwise.
+   * processing has failed; false, otherwise. This property applies only to synchronous mode.
    * - "queued.max.messages.bytes": the maximum amount (in bytes) of queued
    * messages waiting for being processed. The same queue is shared by all callbacks.
    * - "subscription.backoff.min.ms": the initial backoff time (in miliseconds) for
@@ -146,6 +156,8 @@ module.exports = class Consumer {
     // configuration
     this.config = config || {};
 
+    logger.info(`Config:\n ${JSON.stringify(config)}`);
+
     // kafka consumer configuration
     this.config['kafka.consumer'] = this.config['kafka.consumer'] || {};
     this.config['kafka.consumer']['enable.auto.commit'] = false;
@@ -157,6 +169,11 @@ module.exports = class Consumer {
     // wrapper-specific configuration
     this.config['in.processing.max.messages'] = (
       this.config['in.processing.max.messages'] || DEFAULT_IN_PROCESSING_MAX_MESSAGES
+    );
+    this.config['enable.async.commit'] = (
+      (this.config['enable.async.commit'] === undefined)
+        ? DEFAULT_ENABLE_ASYNC_COMMIT
+        : this.config['enable.async.commit']
     );
     this.config['max.retries.processing.callbacks'] = (
       this.config['max.retries.processing.callbacks'] || DEFAULT_MAX_RETRIES_PROCESSING_CALLBACKS
@@ -206,12 +223,23 @@ module.exports = class Consumer {
     }, this.config['in.processing.max.messages']);
     this.msgQueue.drain(this.resumeConsumer.bind(this));
 
-    // log consumer settings
-    logger.info(`Consumer configuration ${JSON.stringify(this.config)}`);
-    logger.info(`Kafka features: ${Kafka.features}`);
+    // define sync or async commit mode handler
+    this.invokeInterestedCallbacks = (this.config['enable.async.commit']
+      ? this.invokeInterestedCallbacksAsyncCommit
+      : this.invokeInterestedCallbacksSyncCommit);
+    this.invokeInterestedCallbacks.bind(this);
+
+    // async commit mode
+    this.unackMsgBytes = 0;
+    this.unackMsgs = {};
+    this.epoch = 0;
 
     // event emitter
     this.eventEmitter = new events.EventEmitter();
+
+    // log consumer settings
+    logger.info(`Consumer configuration ${JSON.stringify(this.config)}`);
+    logger.info(`Kafka features: ${Kafka.features}`);
   }
 
   /**
@@ -240,8 +268,8 @@ module.exports = class Consumer {
       });
 
       /**
-       * this event is reached only when consumer.disconnect is called
-       * otherwise the consumer will keep try ro reconnect
+       * this event is reached only when consumer.disconnect() is called
+       * otherwise the consumer will keep trying to reconnect
        */
       this.consumer.on('disconnected', (arg) => {
         this.isReady = false;
@@ -251,6 +279,9 @@ module.exports = class Consumer {
         this.currQueueBytes = 0;
         this.isPaused = false;
         this.msgQueue = null;
+        this.unackMsgs = {};
+        this.unackMsgBytes = 0;
+        this.epoch = 0;
         this.eventEmitter.emit('disconnected');
         logger.info(`Consumer disconnected. ${util.inspect(arg)}`);
       });
@@ -529,6 +560,9 @@ module.exports = class Consumer {
       // when partition are revoked we just abort queued tasks and do not
       // commit any processed task that is waiting for be commited into Kafka.
       this.msgQueue.remove(() => true);
+      this.unackMsgs = {};
+      this.unackMsgBytes = 0;
+      this.epoch = (this.epoch + 1) % Number.MAX_SAFE_INTEGER;
       this.consumer.unassign();
       this.commitManager.onRebalance();
     } else {
@@ -558,11 +592,15 @@ module.exports = class Consumer {
     });
 
     logger.debug(`Current queue utilization:
-    ${this.currQueueBytes}/${this.config['queued.max.messages.bytes']} bytes`);
+    (${this.currQueueBytes} + ${this.unackMsgBytes})`
+    + `/${this.config['queued.max.messages.bytes']} bytes`);
 
-    // checks is the queue is full or not
-    if (this.currQueueBytes > this.config['queued.max.messages.bytes']) {
-      logger.info('Consumer paused due to queue capacity overflow');
+    // checks if the backpressure stop condition is met
+    // enqueued messages (not delivered) + unprocessed messages (delivered, but waiting for ack)
+    if (this.currQueueBytes + this.unackMsgBytes > this.config['queued.max.messages.bytes']) {
+      logger.info('Consumer paused due to processing queue capacity overflow.'
+      + ` Enqueued Messages: ${this.currQueueBytes} (bytes).`
+      + ` Unacknowledged Messages: ${this.unackMsgBytes} (bytes).`);
       this.consumer.pause(this.consumer.assignments());
       this.isPaused = true;
       this.eventEmitter.emit('paused');
@@ -571,17 +609,19 @@ module.exports = class Consumer {
 
   /**
    * Given a kafka message this method invokes all interested callbacks based on
-   * the message's topic
+   * the message's topic and mark it to be committed in a synchronous way.
    *
    * If a processing callback throws an exception, the callback will be recalled
    * by n-times according its configuration. If the callback
    * has not succeeded after the n-retries, an 'error.processing' event is emitted.
    *
    * Depending on the configuration, the message that coundn't be processed is
-   * commited to Kafka, and the consumer continues working as nothing has
-   * happened (message discarded). But, if the message can't be discarded, it
-   * won't be commited to Kafka and since no newer message won't be commited too
-   * the consumer will be disconnected.
+   * marked to be committed on Kafka, and the consumer continues working as nothing
+   * has happened (message discarded). But, if the message can't be discarded, it
+   * won't be marked to be committed on Kafka and  the consumer will be finished.
+   *
+   * It worths to say that in the synchronous mode the messages are marked to be
+   * committed after the callbacks return.
    *
    * @access private
    * @param {*} data the kafka message with the following attributes:
@@ -595,7 +635,7 @@ module.exports = class Consumer {
    *   timestamp: 1510325354780, // timestamp of message creation
    * }
    */
-  async invokeInterestedCallbacks(data) {
+  async invokeInterestedCallbacksSyncCommit(data) {
     let anyProcessingFailure = false;
     try {
       // verifies if the topic does not matches with a regular expression
@@ -660,6 +700,164 @@ module.exports = class Consumer {
       } else {
         logger.error('Consumer cannot keep working properly. Finishing consumer.');
         this.finish();
+      }
+    }
+  }
+
+  /**
+   * Given a kafka message this method invokes all interested callbacks based on
+   * the message's topic and mark it to be committed in an asynchronous way.
+   *
+   * If a processing callback throws an exception, the callback will be recalled
+   * by n-times according its configuration. If the callback
+   * has not succeeded after all retries, an 'error.processing' event is emitted
+   * and the consumer is finished up.
+   *
+   * It worths to say that in the asynchronous mode the messages are marked to be
+   * committed after receiving the acknowledgments.
+   *
+   * @access private
+   * @param {*} data the kafka message with the following attributes:
+   * {
+   *   value: Buffer.from('konnichiwa'), // message contents as a Buffer
+   *   size: 10, // size of the message, in bytes
+   *   topic: 'greetings', // topic the message comes from
+   *   offset: 1337, // offset the message was read from
+   *   partition: 1, // partition the message was on
+   *   key: 'someKey', // key of the message if present
+   *   timestamp: 1510325354780, // timestamp of message creation
+   * }
+   */
+  async invokeInterestedCallbacksAsyncCommit(data) {
+    // the current epoch
+    const { epoch } = this;
+
+    // key of the kafka message
+    const key = JSON.stringify({
+      topic: data.topic,
+      partition: data.partition,
+      offset: data.offset,
+    });
+
+    // acknowledge callback
+    //
+    // It is supposed that the ack will be called if
+    // and only if its corresponding callback succeeded.
+    const ack = () => {
+      if (epoch !== this.epoch
+        || !Object.prototype.hasOwnProperty.call(this.unackMsgs, key)) return;
+      this.unackMsgs[key] -= 1;
+      if (this.unackMsgs[key] === 0) {
+        this.commitManager.notifyFinishedProcessing(data);
+        this.unackMsgBytes -= data.size;
+        delete this.unackMsgs[key];
+      }
+    };
+
+    // sets here to guarantee that all callbacks are called
+    // before committing on Kafka.
+    this.unackMsgs[key] = 1;
+
+    // set backpressure control
+    this.unackMsgBytes += data.size;
+
+    //  true if any callback has failed
+    let anyProcessingFailure = false;
+
+    try {
+      // verifies if the topic does not matches with a regular expression
+      this.topicRegExpArray.forEach(async (entry) => {
+        if (entry.regExp.test(data.topic)) {
+          let retry = 0;
+          let succeeded = false;
+          this.unackMsgs[key] += 1;
+
+          // called is a guard to guarantee that ack
+          // is called once by each callback
+          let called = false;
+          const ackOnce = () => {
+            if (!called) {
+              called = true;
+              ack();
+            }
+          };
+
+          /* eslint-disable no-await-in-loop */
+          do {
+            logger.debug(`Message on topic: ${data.topic}. `
+              + `Calling callback: ${entry.id}. `
+              + `Attempt: ${retry + 1}/${this.config['max.retries.processing.callbacks']}`);
+            try {
+              await entry.callback(data, ackOnce);
+              succeeded = true;
+            } catch (error) {
+              logger.warn(`Error on user's callback ${entry.id} topic: ${data.topic}: ${error}. Attempt: ${retry + 1}`);
+              retry += 1;
+            }
+          } while ((!succeeded) && retry <= this.config['max.retries.processing.callbacks']);
+          if (!succeeded) {
+            logger.error(`Callback ${entry.id} failed in all attempts (${retry})`);
+            this.unackMsgs[key] -= 1;
+            anyProcessingFailure = true;
+            this.eventEmitter.emit('error.processing', entry.id, data);
+          }
+        }
+      });
+      // checks if there isn't a handler to the topic explicitly
+      if (!this.topicMap[data.topic]) {
+        // just skip
+        return;
+      }
+      // iterates by the callbacks
+      this.topicMap[data.topic].forEach(async (entry) => {
+        let retry = 0;
+        let succeeded = false;
+        this.unackMsgs[key] += 1;
+
+        // called is guard to guarantee that ack
+        // is called once by each callback
+        let called = false;
+        const ackOnce = () => {
+          if (!called) {
+            called = true;
+            ack();
+          }
+        };
+
+        /* eslint-disable no-await-in-loop */
+        do {
+          logger.debug(`Message on topic: ${data.topic}. `
+            + `Calling callback: ${entry.id}. `
+            + `Attempt: ${retry + 1}/${this.config['max.retries.processing.callbacks']}`);
+          try {
+            await entry.callback(data, ackOnce);
+            succeeded = true;
+          } catch (error) {
+            logger.warn(`Error on user's callback ${entry.id} topic: ${data.topic}: ${error}. Attempt: ${retry + 1}`);
+            retry += 1;
+          }
+        } while ((!succeeded) && retry <= this.config['max.retries.processing.callbacks']);
+        if (!succeeded) {
+          logger.error(`Callback ${entry.id} failed in all attempts (${retry})`);
+          this.unackMsgs[key] -= 1;
+          anyProcessingFailure = true;
+          this.eventEmitter.emit('error.processing', entry.id, data);
+        }
+      });
+    } catch (error) {
+      logger.warn(`Internal error during processing message: ${error}`);
+      this.eventEmitter.emit('error.processing', null, data);
+    } finally {
+      this.unackMsgs[key] -= 1;
+      if (anyProcessingFailure) {
+        this.unackMsgBytes -= data.size;
+        delete this.unackMsgs[key];
+        logger.error('Consumer cannot keep working properly. Finishing consumer.');
+        this.finish();
+      } else if (this.unackMsgs[key] === 0) {
+        this.unackMsgBytes -= data.size;
+        delete this.unackMsgs[key];
+        this.commitManager.notifyFinishedProcessing(data);
       }
     }
   }

--- a/lib/kafka/Consumer.js
+++ b/lib/kafka/Consumer.js
@@ -755,9 +755,9 @@ module.exports = class Consumer {
     // and only if its corresponding callback succeeded.
     const ack = () => {
       if (epoch !== this.epoch) {
-          return false;
+        return false;
       }
-      unackCounter -=1;
+      unackCounter -= 1;
       if (unackCounter === 0) {
         this.commitManager.notifyFinishedProcessing(data);
         this.unackMsgBytes -= data.size;

--- a/lib/kafka/README.md
+++ b/lib/kafka/README.md
@@ -12,15 +12,15 @@ To read messages from Kafka, you use the Consumer class, which is a wrapper over
 
 * a commit management that ensures that all messages are processed at least once.
 
-The consumer has two exlusive modes of operation:
+The consumer has two exclusive modes of operation:
 
-* Synchronous - a message is marked to be committed immediately after its processing callbacks have finished successfuly. If any callback throws an Error, it will be retried by a given number of times. If it keeps failing, the message will be marked to be commited only if the property 'commit.on.failure' is 'true'; otherwise, the consumer will be finished up. In both cases, an 'error.processing' event is emitted.
+* Synchronous - a message is marked to be committed immediately after its processing callbacks have finished successfully. If any callback throws an Error, it will be retried by a given number of times. If it keeps failing, the message will be marked to be committed only if the property 'commit.on.failure' is 'true'; otherwise, the consumer will be finished up. In both cases, an 'error.processing' event is emitted.
 
-* Asynchronous - a message is marked to be committed immediately after its acknoledgements have been received. If any callback throws an Error, it will be retried by a given number of times. If it keeps failing, the consumer will be finished up and an 'error.processing' event will be emitted.
+* Asynchronous - a message is marked to be committed immediately after its acknowledgements have been received. If any callback throws an Error, it will be retried by a given number of times. If it keeps failing, the consumer will be finished up and an 'error.processing' event will be emitted.
 
 Once the consumer is finished due to an unprocessed message, the application will need to instantiate a new one which will start consuming from the earliest uncommitted message.
 
-In the asynchronous mode, the responsability for acknowledging a message is entirely of the application, and forgetting to acknowledge will eventually block the consumer.
+In the asynchronous mode, the responsibility for acknowledging a message is entirely of the application, and forgetting to acknowledge will eventually block the consumer.
 
 The following example illustrates how to use the Synchronous Consumer:
 
@@ -103,7 +103,7 @@ The following properties can be set for the Consumer:
 |in.processing.max.messages|The maximum number of messages being processed simultaneously. The processing callbacks are called in order but there is no guarantee regarding to the order of completion. Default value is 1.|
 |max.retries.processing.callbacks|The maximum number of times a processing
 callback is called if it fails. Default value is 0.|
-|enable.async.commit| True whether asynchronous mode is enabled; otherwise, fasle. Default value is false.|
+|enable.async.commit| True whether asynchronous mode is enabled; otherwise, false. Default value is false.|
 |commit.on.failure|True whether a message should be committed even if any of its
 processing callback has failed; false, otherwise. Default value is true.|
 |queued.max.messages.bytes|The maximum amount (in bytes) of queued messages waiting for being processed. The same queue is shared by all callbacks. Default value is 10485760.|

--- a/lib/kafka/README.md
+++ b/lib/kafka/README.md
@@ -4,16 +4,25 @@ The Kafka module provides a high-level abstraction for Kafka Producers and Consu
 
 # Consumer
 
-To read messages from Kafka, you use the Consumer class, which is a wrapper over the
-node-rdkafka Consumer and provides the following additional features:
+To read messages from Kafka, you use the Consumer class, which is a wrapper over the node-rdkafka Consumer and provides the following additional features:
 
 * a register callback system with allows multiple callbacks to be registered for processing the same message;
 
 * a backpressure mechanism to control the consumption of messages from kafka according to the processing ratio. If messages are consumed at a higher rate than they are processed, consumption is stopped until messages already consumed are processed;
 
-* a commit management that ensures that all messages are processed at least once. A message is considered processed after all registered callbacks for it have finished successfuly. Nevertheless, if some of the registered callbacks throws an Error, there will be two possibilities. The first one, which is the default, the message will be considered discarded by the callback and will be committed on Kafka. The second one, the message will be considered unprocessed and the consumer will be finished up. In both cases, an 'error.processing' event is emitted. It is also possible to set a maximum number of retries to failed callbacks. Once the consumer is finished, the application will need to instantiate a new one which will start consuming from the last unprocessed message.
+* a commit management that ensures that all messages are processed at least once.
 
-The following example illustrates how to use the Consumer:
+The consumer has two exlusive modes of operation:
+
+* Synchronous - a message is marked to be committed immediately after its processing callbacks have finished successfuly. If any callback throws an Error, it will be retried by a given number of times. If it keeps failing, the message will be marked to be commited only if the property 'commit.on.failure' is 'true'; otherwise, the consumer will be finished up. In both cases, an 'error.processing' event is emitted.
+
+* Asynchronous - a message is marked to be committed immediately after its acknoledgements have been received. If any callback throws an Error, it will be retried by a given number of times. If it keeps failing, the consumer will be finished up and an 'error.processing' event will be emitted.
+
+Once the consumer is finished due to an unprocessed message, the application will need to instantiate a new one which will start consuming from the earliest uncommitted message.
+
+In the asynchronous mode, the responsability for acknowledging a message is entirely of the application, and forgetting to acknowledge will eventually block the consumer.
+
+The following example illustrates how to use the Synchronous Consumer:
 
 ```js
 const { Kafka: { Consumer } } = require('@dojot/microservice-sdk');
@@ -48,6 +57,43 @@ consumer.init().then(() => {
 });
 ```
 
+The following example illustrates how to use the Asynchronous Consumer:
+
+```js
+const { Kafka: { Consumer } } = require('@dojot/microservice-sdk');
+
+const consumer = new Consumer({
+  'enable.async.commit': true,
+  'kafka.consumer': {
+    'group.id': 'sdk-consumer-example',
+    'metadata.broker.list': 'localhost:9092',
+  }
+});
+
+// register on consumer's events
+consumer.on('ready', () => console.log('Received ready event'));
+consumer.on('disconnected', () => console.log('Received disconnected event'));
+consumer.on('paused', () => console.log('Received paused event'));
+consumer.on('resumed', () => console.log('Received resumed event'));
+consumer.on('error.connecting', () => console.log('Received error.connecting event'));
+consumer.on('error.processing', (cbId, data) => console.log(`Received error.processing event (cbId: ${cbId}: data: ${JSON.stringfy(data)}`));
+
+consumer.init().then(() => {
+    // the target kafka topic, it could be a String or a RegExp
+    const topic = "consumer.example.test";
+
+    // Register callback for processing incoming data
+    consumer.registerCallback(topic, (data, ack) => {
+        // Data processing
+        const { value: payload } = data;
+        console.log(`Payload: ${payload.toString()}`);
+        ack();
+    });
+}).catch((error) => {
+    console.error(`Caught an error: ${error.stack || error}`);
+});
+```
+
 ## Configuration
 
 The following properties can be set for the Consumer:
@@ -57,6 +103,7 @@ The following properties can be set for the Consumer:
 |in.processing.max.messages|The maximum number of messages being processed simultaneously. The processing callbacks are called in order but there is no guarantee regarding to the order of completion. Default value is 1.|
 |max.retries.processing.callbacks|The maximum number of times a processing
 callback is called if it fails. Default value is 0.|
+|enable.async.commit| True whether asynchronous mode is enabled; otherwise, fasle. Default value is false.|
 |commit.on.failure|True whether a message should be committed even if any of its
 processing callback has failed; false, otherwise. Default value is true.|
 |queued.max.messages.bytes|The maximum amount (in bytes) of queued messages waiting for being processed. The same queue is shared by all callbacks. Default value is 10485760.|

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,6 +19,8 @@
         "fast-safe-stringify": "^2.0.7",
         "flat": "^5.0.0",
         "http-errors": "^1.8.0",
+        "jsonwebtoken": "^8.5.1",
+        "jwt-decode": "^3.1.2",
         "lightship": "^6.2.1",
         "lodash": "^4.17.19",
         "morgan": "^1.10.0",
@@ -2007,6 +2009,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2711,6 +2718,14 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -6542,6 +6557,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6556,6 +6605,30 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -6763,10 +6836,45 @@
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
     "node_modules/lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",

--- a/test/unit/kafka/Consumer.test.js
+++ b/test/unit/kafka/Consumer.test.js
@@ -714,8 +714,6 @@ describe('handle kafka (Async Commit)', () => {
 
     let ack1;
     let ack2;
-    let ack1Return;
-    let ack2Return;
     consumer.topicRegExpArray[0].callback = jest
       .fn()
       .mockImplementationOnce((data, ack) => {
@@ -729,8 +727,8 @@ describe('handle kafka (Async Commit)', () => {
       });
 
     await consumer.invokeInterestedCallbacks(publishedData);
-    ack2Return = ack2();
-    ack1Return = ack1();
+    const ack2Return = ack2();
+    const ack1Return = ack1();
 
     expect(consumer.topicRegExpArray[0].callback)
       .toHaveBeenCalledWith(publishedData, expect.any(Function));
@@ -876,7 +874,7 @@ describe('handle kafka (Async Commit)', () => {
       .fn()
       .mockImplementationOnce((data, ack) => {
         ack1Return = ack();
-        ack2Return = ack(); //second call
+        ack2Return = ack(); // second call
       });
 
     consumer.topicMap[publishedData.topic][0].callback = jest
@@ -1102,8 +1100,6 @@ describe('handle kafka (Async Commit)', () => {
 
     let ack1;
     let ack2;
-    let ack1Return;
-    let ack2Return;
 
     consumer.topicRegExpArray[0].callback = jest
       .fn()
@@ -1124,8 +1120,8 @@ describe('handle kafka (Async Commit)', () => {
     consumer.epoch += 1;
 
     // late acknowledgements (previous epoch)
-    ack1Return = ack1();
-    ack2Return = ack2();
+    const ack1Return = ack1();
+    const ack2Return = ack2();
 
     expect(consumer.topicRegExpArray[0].callback)
       .toHaveBeenCalledWith(publishedData, expect.any(Function));


### PR DESCRIPTION
Now the consumer might wait for an acknowledgement to mark
a message to be commited instead of just waiting for the return
of the processing callback.

* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
The consumer marks a message to be committed after the processing callback returns. We call this 'sync commit'.


* **What is the new behavior (if this is a feature change)?**
Now, the consumer might mark a message to be committed after receiving an acknowledgement. We call this 'async mode'.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#1899

* **Other information**: